### PR TITLE
Split HttpClient Resilience

### DIFF
--- a/Exthand.Gateway.csproj
+++ b/Exthand.Gateway.csproj
@@ -16,9 +16,9 @@
     <PackageLicenseExpression>MIT OR Apache-2.0</PackageLicenseExpression>
     <Description>This library connects your app to our Open Banking SAAS. You can then easily initiate payment (PIS), access bank accounts transactions and balances (AIS) and execute VOP (Verification Of Payee) over 2500 open bank APIs worldwide.</Description>
     <PackageTags>psd2 open banking exthand finance payments account statement transaction vop ais pis</PackageTags>
-    <PackageVersion>8.1.1</PackageVersion>
-    <ReleaseVersion>8.1.1</ReleaseVersion>
-    <Version>8.1.1</Version>
+    <PackageVersion>8.2.0</PackageVersion>
+    <ReleaseVersion>8.2.0</ReleaseVersion>
+    <Version>8.2.0</Version>
     <Configurations>Release;Debug</Configurations>
     <Title>Exthand.Gateway</Title>
   </PropertyGroup>

--- a/GatewayConfigurator.cs
+++ b/GatewayConfigurator.cs
@@ -1,23 +1,131 @@
 ﻿using Exthand.GatewayClient.Interface;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Http.Resilience;
+using Polly;
 using System;
 using System.Net.Http;
-using System.Threading.Tasks;
 
 namespace Exthand.GatewayClient
 {
+    /// <summary>
+    /// Tunables for the resilience pipelines applied to the gateway HTTP clients.
+    /// Defaults are sized for Open Banking calls — which are slow (AIS transaction pulls can take
+    /// minutes) and rate-limited by the banks — NOT for fast micro-service calls. They intentionally
+    /// differ from <c>AddStandardResilienceHandler()</c>'s defaults (30 s total / 10 s per attempt),
+    /// which would cut off legitimate slow bank calls.
+    /// </summary>
+    public class GatewayResilienceOptions
+    {
+        /// <summary>Timeout for a single HTTP attempt. Bank calls can be slow, so this is generous.</summary>
+        public TimeSpan AttemptTimeout { get; set; } = TimeSpan.FromSeconds(120);
+
+        /// <summary>Overall timeout for the whole pipeline (all attempts). Must be &gt;= <see cref="AttemptTimeout"/>.</summary>
+        public TimeSpan TotalRequestTimeout { get; set; } = TimeSpan.FromSeconds(300);
+
+        /// <summary>
+        /// Retry attempts for IDEMPOTENT operations only (reads, status, deletes). Payment/consent/user
+        /// writes are NEVER retried, regardless of this value.
+        /// </summary>
+        public int MaxRetryAttempts { get; set; } = 2;
+
+        /// <summary>Base delay for the (jittered, exponential) retry backoff.</summary>
+        public TimeSpan RetryBaseDelay { get; set; } = TimeSpan.FromSeconds(1);
+
+        /// <summary>Circuit-breaker failure ratio (0..1) over the sampling window that opens the breaker.</summary>
+        public double CircuitBreakerFailureRatio { get; set; } = 0.5;
+
+        /// <summary>Minimum calls in the sampling window before the breaker can open. Low, to suit a low-volume gateway.</summary>
+        public int CircuitBreakerMinimumThroughput { get; set; } = 10;
+
+        /// <summary>Sampling window for the circuit breaker.</summary>
+        public TimeSpan CircuitBreakerSamplingDuration { get; set; } = TimeSpan.FromSeconds(240);
+
+        /// <summary>How long the breaker stays open before probing again.</summary>
+        public TimeSpan CircuitBreakerBreakDuration { get; set; } = TimeSpan.FromSeconds(15);
+    }
+
     public static class GatewayConfigurator
     {
+        /// <summary>
+        /// Named client for IDEMPOTENT operations (reads, status, deletes):
+        /// timeout -&gt; retry -&gt; circuit breaker -&gt; per-attempt timeout.
+        /// </summary>
+        public const string ClientName = "BankingSdkGatewayClient";
+
+        /// <summary>
+        /// Named client for NON-IDEMPOTENT operations (payment/consent init &amp; finalize, user creation):
+        /// timeout -&gt; circuit breaker -&gt; per-attempt timeout, with NO retry — a timed-out write may already
+        /// have been processed by the bank, so retrying could duplicate it (e.g. a double payment).
+        /// </summary>
+        public const string ClientNameNoRetry = "BankingSdkGatewayClientNoRetry";
+
+        /// <summary>
+        /// Backwards-compatible overload. <paramref name="httpClientTimeoutMilliseconds"/> becomes the total
+        /// request timeout; the per-attempt timeout is capped at the same value (max 120 s).
+        /// </summary>
         public static void AddGatewayService(this IServiceCollection services, Uri serverUrl, int httpClientTimeoutMilliseconds = 300000)
         {
-            services.AddHttpClient("BankingSdkGatewayClient", c =>
+            var total = TimeSpan.FromMilliseconds(httpClientTimeoutMilliseconds);
+            var options = new GatewayResilienceOptions
+            {
+                TotalRequestTimeout = total,
+                AttemptTimeout = total < TimeSpan.FromSeconds(120) ? total : TimeSpan.FromSeconds(120)
+            };
+            services.AddGatewayService(serverUrl, options);
+        }
+
+        /// <summary>
+        /// Registers the gateway client with two resilience profiles: a retrying one for idempotent
+        /// operations and a non-retrying one for payment/consent/user writes.
+        /// </summary>
+        public static void AddGatewayService(this IServiceCollection services, Uri serverUrl, GatewayResilienceOptions options)
+        {
+            if (options is null)
+                options = new GatewayResilienceOptions();
+
+            // Idempotent operations: timeout -> retry -> circuit breaker -> per-attempt timeout.
+            services.AddHttpClient(ClientName, c =>
             {
                 c.BaseAddress = serverUrl;
-                c.Timeout = TimeSpan.FromMilliseconds(httpClientTimeoutMilliseconds);
-            }).AddStandardResilienceHandler(); 
-            
+                c.Timeout = System.Threading.Timeout.InfiniteTimeSpan; // the resilience pipeline owns timeouts
+            }).AddResilienceHandler("gw-idempotent", builder =>
+            {
+                builder
+                    .AddTimeout(options.TotalRequestTimeout)
+                    .AddRetry(new HttpRetryStrategyOptions
+                    {
+                        MaxRetryAttempts = options.MaxRetryAttempts,
+                        BackoffType = DelayBackoffType.Exponential,
+                        UseJitter = true,
+                        Delay = options.RetryBaseDelay
+                    })
+                    .AddCircuitBreaker(BuildBreaker(options))
+                    .AddTimeout(options.AttemptTimeout);
+            });
+
+            // Non-idempotent operations: NO retry (only timeout + circuit breaker).
+            services.AddHttpClient(ClientNameNoRetry, c =>
+            {
+                c.BaseAddress = serverUrl;
+                c.Timeout = System.Threading.Timeout.InfiniteTimeSpan;
+            }).AddResilienceHandler("gw-write", builder =>
+            {
+                builder
+                    .AddTimeout(options.TotalRequestTimeout)
+                    .AddCircuitBreaker(BuildBreaker(options))
+                    .AddTimeout(options.AttemptTimeout);
+            });
+
             services.AddScoped<IGatewayService, GatewayService>();
         }
+
+        private static HttpCircuitBreakerStrategyOptions BuildBreaker(GatewayResilienceOptions options)
+            => new HttpCircuitBreakerStrategyOptions
+            {
+                FailureRatio = options.CircuitBreakerFailureRatio,
+                MinimumThroughput = options.CircuitBreakerMinimumThroughput,
+                SamplingDuration = options.CircuitBreakerSamplingDuration,
+                BreakDuration = options.CircuitBreakerBreakDuration
+            };
     }
-    
 }

--- a/GatewayService.cs
+++ b/GatewayService.cs
@@ -79,7 +79,7 @@ namespace Exthand.GatewayClient
         /// <returns>A list of Bank objects.</returns>
         public async Task<BankList> GetBanksAsync(string countryCode="", string? XRequestID=null)
         {
-            var client = _httpClientFactory.CreateClient("BankingSdkGatewayClient");
+            var client = _httpClientFactory.CreateClient(GatewayConfigurator.ClientName);
             client = SetHeaders(client, XRequestID);
             var result = await client.GetAsync("ob/banks?countryCode=" + countryCode);
 
@@ -104,7 +104,7 @@ namespace Exthand.GatewayClient
 
         public async Task<GatewayString> FindFlowIdAsync(string queryString, string? XRequestID=null)
         {
-            var client = _httpClientFactory.CreateClient("BankingSdkGatewayClient");
+            var client = _httpClientFactory.CreateClient(GatewayConfigurator.ClientName);
             client = SetHeaders(client, XRequestID);
             
             var result = await client.GetAsync("ob/findFlowId?queryString=" + HttpUtility.UrlEncode(queryString));
@@ -129,7 +129,7 @@ namespace Exthand.GatewayClient
         public async Task<BankPaymentAccessOption> GetBankPaymentAccessOptionsAsync(int connectorId, string? XRequestID=null)
         {
 
-            var client = _httpClientFactory.CreateClient("BankingSdkGatewayClient");
+            var client = _httpClientFactory.CreateClient(GatewayConfigurator.ClientName);
             client = SetHeaders(client, XRequestID);
             
             var result = await client.GetAsync("ob/pis/payments/options/" + connectorId.ToString());
@@ -151,7 +151,7 @@ namespace Exthand.GatewayClient
 
         public async Task<PaymentInitResponse> PaymentInitiateAsync(PaymentInitRequest paymentInitRequest, string? XRequestID=null)
         {
-            var client = _httpClientFactory.CreateClient("BankingSdkGatewayClient");
+            var client = _httpClientFactory.CreateClient(GatewayConfigurator.ClientNameNoRetry);
             client = SetHeaders(client, XRequestID);
             
             var stringContent = new StringContent(JsonConvert.SerializeObject(paymentInitRequest), Encoding.UTF8, "application/json");
@@ -177,7 +177,7 @@ namespace Exthand.GatewayClient
 
         public async Task<PaymentFinalizeResponse> PaymentFinalizeAsync(PaymentFinalizeRequest paymentFinalizeRequest, string? XRequestID=null)
         {
-            var client = _httpClientFactory.CreateClient("BankingSdkGatewayClient");
+            var client = _httpClientFactory.CreateClient(GatewayConfigurator.ClientNameNoRetry);
             client = SetHeaders(client, XRequestID);
             
             var stringContent = new StringContent(JsonConvert.SerializeObject(paymentFinalizeRequest), Encoding.UTF8, "application/json");
@@ -202,7 +202,7 @@ namespace Exthand.GatewayClient
         public async Task<PaymentStatusResponse> PaymentStatusAsync(PaymentStatusRequest paymentStatusRequest, string? XRequestID=null)
         {
 
-            var client = _httpClientFactory.CreateClient("BankingSdkGatewayClient");
+            var client = _httpClientFactory.CreateClient(GatewayConfigurator.ClientName);
             client = SetHeaders(client, XRequestID);
             
             var stringContent = new StringContent(JsonConvert.SerializeObject(paymentStatusRequest), Encoding.UTF8, "application/json");
@@ -230,8 +230,8 @@ namespace Exthand.GatewayClient
         /// <returns></returns>
         public async Task<AccountsForPaymentResponseInit> GetAccountsForPaymentsInitAsync(AccountsForPaymentRequestInit accountsForPaymentRequestInit, string? XRequestID=null)
         {
-           
-            var client = _httpClientFactory.CreateClient("BankingSdkGatewayClient");
+
+            var client = _httpClientFactory.CreateClient(GatewayConfigurator.ClientNameNoRetry);
             client = SetHeaders(client, XRequestID);
             
             var stringContent = new StringContent(JsonConvert.SerializeObject(accountsForPaymentRequestInit), Encoding.UTF8, "application/json");
@@ -260,7 +260,7 @@ namespace Exthand.GatewayClient
         /// <returns></returns>
         public async Task<AccountsForPaymentFinalize> GetAccountsForPaymentsFinalizeAsync(AccountsForPaymentFinalizeRequest accountsForPaymentFinalizeRequest, string? XRequestID=null)
         {
-            var client = _httpClientFactory.CreateClient("BankingSdkGatewayClient");
+            var client = _httpClientFactory.CreateClient(GatewayConfigurator.ClientNameNoRetry);
             client = SetHeaders(client, XRequestID);
             
             var stringContent = new StringContent(JsonConvert.SerializeObject(accountsForPaymentFinalizeRequest), Encoding.UTF8, "application/json");
@@ -288,7 +288,7 @@ namespace Exthand.GatewayClient
         
         public async Task<BulkPaymentInitResponse> BulkPaymentInitiateAsync(BulkPaymentInitRequest bulkPaymentInitRequest, string? XRequestID=null)
         {
-            var client = _httpClientFactory.CreateClient("BankingSdkGatewayClient");
+            var client = _httpClientFactory.CreateClient(GatewayConfigurator.ClientNameNoRetry);
             client = SetHeaders(client, XRequestID);
             
             var stringContent = new StringContent(JsonConvert.SerializeObject(bulkPaymentInitRequest), Encoding.UTF8, "application/json");
@@ -313,7 +313,7 @@ namespace Exthand.GatewayClient
 
         public async Task<BulkPaymentFinalizeResponse> BulkPaymentFinalizeAsync(BulkPaymentFinalizeRequest bulkPaymentFinalizeRequest, string? XRequestID=null)
         {
-            var client = _httpClientFactory.CreateClient("BankingSdkGatewayClient");
+            var client = _httpClientFactory.CreateClient(GatewayConfigurator.ClientNameNoRetry);
             client = SetHeaders(client, XRequestID);
             
             var stringContent = new StringContent(JsonConvert.SerializeObject(bulkPaymentFinalizeRequest), Encoding.UTF8, "application/json");
@@ -338,7 +338,7 @@ namespace Exthand.GatewayClient
         public async Task<BulkPaymentStatusResponse> BulkPaymentStatusAsync(BulkPaymentStatusRequest bulkPaymentStatusRequest, string? XRequestID=null)
         {
 
-            var client = _httpClientFactory.CreateClient("BankingSdkGatewayClient");
+            var client = _httpClientFactory.CreateClient(GatewayConfigurator.ClientName);
             client = SetHeaders(client, XRequestID);
             
             var stringContent = new StringContent(JsonConvert.SerializeObject(bulkPaymentStatusRequest), Encoding.UTF8, "application/json");
@@ -373,7 +373,7 @@ namespace Exthand.GatewayClient
         /// <exception cref="Exception"></exception>
         public async Task<BankAccessOption> GetBankAccessOptionsAsync(int connectorId, string? XRequestID=null)
         {
-            var client = _httpClientFactory.CreateClient("BankingSdkGatewayClient");
+            var client = _httpClientFactory.CreateClient(GatewayConfigurator.ClientName);
             
             client = SetHeaders(client, XRequestID);
             
@@ -404,7 +404,7 @@ namespace Exthand.GatewayClient
         /// <returns></returns>
         public async Task<BankAccessResponse> RequestBankAccessAsync(BankAccessRequest bankAccessRequest, string? XRequestID=null)
         {
-            var client = _httpClientFactory.CreateClient("BankingSdkGatewayClient");
+            var client = _httpClientFactory.CreateClient(GatewayConfigurator.ClientNameNoRetry);
             client = SetHeaders(client, XRequestID);
             
             var stringContent = new StringContent(JsonConvert.SerializeObject(bankAccessRequest), Encoding.UTF8, "application/json");
@@ -433,7 +433,7 @@ namespace Exthand.GatewayClient
         /// <returns></returns>
         public async Task<BankAccessResponseFinalize> FinalizeRequestBankAccessAsync(BankAccessRequestFinalize bankAccessRequestFinalize, string? XRequestID=null)
         {
-            var client = _httpClientFactory.CreateClient("BankingSdkGatewayClient");
+            var client = _httpClientFactory.CreateClient(GatewayConfigurator.ClientNameNoRetry);
             client = SetHeaders(client, XRequestID);
             
             var stringContent = new StringContent(JsonConvert.SerializeObject(bankAccessRequestFinalize), Encoding.UTF8, "application/json");
@@ -462,7 +462,7 @@ namespace Exthand.GatewayClient
         /// <returns>DeleteRequestResponse</returns>
         public async Task<GatewayBool> CancelBankAccessAsync(DeleteConsentRequest deleteConsentRequest, string? XRequestID=null)
         {
-            var client = _httpClientFactory.CreateClient("BankingSdkGatewayClient");
+            var client = _httpClientFactory.CreateClient(GatewayConfigurator.ClientName);
             client = SetHeaders(client, XRequestID);
             
             var stringContent = new StringContent(JsonConvert.SerializeObject(deleteConsentRequest), Encoding.UTF8, "application/json");
@@ -489,7 +489,7 @@ namespace Exthand.GatewayClient
         /// <returns>DeleteAccountResponse</returns>
         public async Task<GatewayBool> RemoveBankAccountAsync(DeleteAccountRequest deleteAccountRequest, string? XRequestID=null)
         {
-            var client = _httpClientFactory.CreateClient("BankingSdkGatewayClient");
+            var client = _httpClientFactory.CreateClient(GatewayConfigurator.ClientName);
             client = SetHeaders(client, XRequestID);
             
             var stringContent = new StringContent(JsonConvert.SerializeObject(deleteAccountRequest), Encoding.UTF8, "application/json");
@@ -512,7 +512,7 @@ namespace Exthand.GatewayClient
         public async Task<BankAccountsResponse> GetBankAccountsAsync(BankAccountsRequest bankAccountsRequest, string? XRequestID=null)
         {
 
-            var client = _httpClientFactory.CreateClient("BankingSdkGatewayClient");
+            var client = _httpClientFactory.CreateClient(GatewayConfigurator.ClientName);
             client = SetHeaders(client, XRequestID);
             
             var stringContent = new StringContent(JsonConvert.SerializeObject(bankAccountsRequest), Encoding.UTF8, "application/json");
@@ -541,7 +541,7 @@ namespace Exthand.GatewayClient
         public async Task<BalanceResponse> GetBalancesAsync(string accountId, BalanceRequest balanceRequest, string? XRequestID=null)
         {
 
-            var client = _httpClientFactory.CreateClient("BankingSdkGatewayClient");
+            var client = _httpClientFactory.CreateClient(GatewayConfigurator.ClientName);
             client = SetHeaders(client, XRequestID);
             
             var stringContent = new StringContent(JsonConvert.SerializeObject(balanceRequest), Encoding.UTF8, "application/json");
@@ -565,7 +565,7 @@ namespace Exthand.GatewayClient
 
         public async Task<TransactionResponse> GetTransactionsAsync(string accountId, TransactionRequest transactionRequest, string? XRequestID=null)
         {
-            var client = _httpClientFactory.CreateClient("BankingSdkGatewayClient");
+            var client = _httpClientFactory.CreateClient(GatewayConfigurator.ClientName);
             client = SetHeaders(client, XRequestID);
             
             var stringContent = new StringContent(JsonConvert.SerializeObject(transactionRequest), Encoding.UTF8, "application/json");
@@ -593,7 +593,7 @@ namespace Exthand.GatewayClient
 
         public async Task<TransactionResponse> GetTransactionsNextAsync(string accountId, TransactionPagingRequest transactionRequest, string? XRequestID=null)
         {
-            var client = _httpClientFactory.CreateClient("BankingSdkGatewayClient");
+            var client = _httpClientFactory.CreateClient(GatewayConfigurator.ClientName);
             client = SetHeaders(client, XRequestID);
             
             var stringContent = new StringContent(JsonConvert.SerializeObject(transactionRequest), Encoding.UTF8, "application/json");
@@ -627,7 +627,7 @@ namespace Exthand.GatewayClient
         /// <returns>TermsDTO object</returns>
         public async Task<TermsDTO> GetTCAsync(string language="", string? XRequestID=null)
         {
-            var client = _httpClientFactory.CreateClient("BankingSdkGatewayClient");
+            var client = _httpClientFactory.CreateClient(GatewayConfigurator.ClientName);
             client = SetHeaders(client, XRequestID);
             
             var result = await client.GetAsync("ob/gw/tc/latest?language=" + language);
@@ -664,7 +664,7 @@ namespace Exthand.GatewayClient
             if (string.IsNullOrEmpty(psuId))
                 return termsValidatedDTO;
 
-            var client = _httpClientFactory.CreateClient("BankingSdkGatewayClient");
+            var client = _httpClientFactory.CreateClient(GatewayConfigurator.ClientName);
             client = SetHeaders(client, XRequestID);
             
             var result = await client.GetAsync($"ob/gw/users/{psuId}/tc/latest" );
@@ -693,7 +693,7 @@ namespace Exthand.GatewayClient
         public async Task<UserRegisterResponse> CreateUserAsync(UserDTO userDTO, string? XRequestID=null)
         {
 
-            var client = _httpClientFactory.CreateClient("BankingSdkGatewayClient");
+            var client = _httpClientFactory.CreateClient(GatewayConfigurator.ClientNameNoRetry);
             client = SetHeaders(client, XRequestID);
             
             var stringContent = new StringContent(JsonConvert.SerializeObject(userDTO), Encoding.UTF8, "application/json");
@@ -727,7 +727,7 @@ namespace Exthand.GatewayClient
         /// <returns>VopResponse containing the match status</returns>
         public async Task<VopResponse> VerifyPayeeAsync(VopRequest vopRequest, string? XRequestID = null)
         {
-            var client = _httpClientFactory.CreateClient("BankingSdkGatewayClient");
+            var client = _httpClientFactory.CreateClient(GatewayConfigurator.ClientName);
             client = SetHeaders(client, XRequestID);
 
             var stringContent = new StringContent(JsonConvert.SerializeObject(vopRequest), Encoding.UTF8, "application/json");


### PR DESCRIPTION
Added AddStandardResilienceHandler() to HttpClientFactory. This handler will retry failed calls to the gateway. Usefull in interactive mode, when the user is waiting for a response and the gateway is busy or down for a short time.